### PR TITLE
Fix optional handling in ChineseNumberTool parse

### DIFF
--- a/src/main/java/tw/klab/utils/ChineseNumberTool.java
+++ b/src/main/java/tw/klab/utils/ChineseNumberTool.java
@@ -56,7 +56,7 @@ public class ChineseNumberTool {
             var word = mtc.group();
             var nums = word.split("點");
             var arabicOpt = chineseNumeralToArabic(nums[0]);
-            if (nums.length >= 2) {
+            if (arabicOpt.isPresent() && nums.length >= 2) {
                 var dot = chineseCharToArabic(nums[1]);
                 if (dot.length() > 0) {
                     var t = String.format("%d.%s", arabicOpt.get(), dot);


### PR DESCRIPTION
## Summary
- Avoid NoSuchElementException when parsing invalid Chinese numerals with decimal by checking presence before using Optional value.

## Testing
- `javac src/main/java/tw/klab/utils/ChineseNumberTool.java`
- `javac -cp src/main/java Test.java`
- `java -cp .:src/main/java Test`


------
https://chatgpt.com/codex/tasks/task_e_689aa06dea408322b097b277f455386b