### PR TITLE
Support negative numbers and yi unit in ChineseNumberTool

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,15 @@
+plugins {
+    id 'java'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.9.3'
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'com.github.mrsarm.jshell.plugin' version '1.2.1'
 }
 
 repositories {
@@ -7,9 +8,19 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.9.3'
+    // 用 BOM 鎖定版本，避免不同 JUnit 模組版本衝突
+    testImplementation platform('org.junit:junit-bom:5.10.2')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+
+    // Gradle 9 需要顯式加這個
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 test {
     useJUnitPlatform()
 }
+
+tasks.withType(JavaCompile) {
+    options.encoding = 'UTF-8'
+}
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'ChineseNumberTool'

--- a/src/main/java/tw/klab/utils/ChineseNumberTool.java
+++ b/src/main/java/tw/klab/utils/ChineseNumberTool.java
@@ -13,7 +13,8 @@ import java.util.regex.Pattern;
  */
 public class ChineseNumberTool {
 
-    private static final String regexStr = "(十?(?:[零一二兩三四五六七八九][十百千萬]?萬?)+點?[零一二三四五六七八九]*)";
+    // 支援到「億」單位並允許可選的負號
+    private static final String regexStr = "(-?十?(?:[零一二兩三四五六七八九][十百千萬億]?億?萬?)+點?[零一二三四五六七八九]*)";
     private static final Pattern pattern = Pattern.compile(regexStr);
     private static final Map<Character, Character> nextUnit = Map.of(
         '萬', '千',
@@ -43,7 +44,7 @@ public class ChineseNumberTool {
      * 將字串中口語表達的中文數字全部轉為阿拉伯數字。例如輸入：
      * <code>"序號十八號，身高一百零五點七二公分，重量三千兩百五十七點三九公斤，身價五千一百萬"</code>，
      * 將會返回<code>"序號18號，身高105.72公分，重量3257.39公斤，身價51000000"</code>。
-     * 最高只支援到千萬，無法處理億的單位。
+     * 支援到億的單位並可處理負數。
      * <br><br>
      * 如果不需要處理口語表達，只需要一對一的將中文數字轉為阿拉伯數字，可以使用 {@link #chineseCharToArabic(String)}。
      * @param str
@@ -96,6 +97,11 @@ public class ChineseNumberTool {
      * @return 如果轉換成功，返回阿拉伯數字
      */
     public static Optional<Integer> chineseNumeralToArabic(String str) {
+        boolean negative = false;
+        if (str.startsWith("-")) {
+            negative = true;
+            str = str.substring(1);
+        }
         if (str.startsWith("十")) {
             str = "一" + str;
         }
@@ -129,24 +135,32 @@ public class ChineseNumberTool {
             }
             num += reg;
         }
-        return Optional.of(num);
+        return Optional.of(negative ? -num : num);
     }
 
     private static int times(char c, int num) {
+        int abs = Math.abs(num);
+        int rst;
         switch (c) {
             case '十':
-                return num * 10;
+                rst = abs * 10;
+                break;
             case '百':
-                return num * 100;
+                rst = abs * 100;
+                break;
             case '千':
-                return num * 1000;
+                rst = abs * 1000;
+                break;
             case '萬':
-                return num * 10000;
+                rst = abs * 10000;
+                break;
             case '億':
-                return num * 100000000;
+                rst = abs * 100000000;
+                break;
             default:
                 return -1;
         }
+        return num < 0 ? -rst : rst;
     }
 
     private static int change(char c) {

--- a/src/test/java/tw/klab/utils/ChineseNumberToolTest.java
+++ b/src/test/java/tw/klab/utils/ChineseNumberToolTest.java
@@ -1,0 +1,31 @@
+package tw.klab.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ChineseNumberToolTest {
+
+    @Test
+    void parseHandlesYiAndNegative() {
+        String input = "身價-一億零五萬";
+        String expected = "身價-100050000";
+        assertEquals(expected, ChineseNumberTool.parse(input));
+    }
+
+    @Test
+    void parseHandlesDecimal() {
+        String input = "利潤-三點五";
+        String expected = "利潤-3.5";
+        assertEquals(expected, ChineseNumberTool.parse(input));
+    }
+
+    @Test
+    void chineseNumeralToArabicReturnsNegative() {
+        Optional<Integer> value = ChineseNumberTool.chineseNumeralToArabic("-一億零三萬");
+        assertTrue(value.isPresent());
+        assertEquals(-100030000, value.get().intValue());
+    }
+}


### PR DESCRIPTION
## Summary
- allow ChineseNumberTool to parse numbers with the 億 unit and optional leading minus sign
- handle negative values in `chineseNumeralToArabic` and overall parsing logic
- extend `times` to correctly convert 億 and propagate signs
- add Gradle build config and unit tests exercising negative 億 conversions

## Testing
- `gradle test` *(fails: Could not resolve org.junit.jupiter:junit-jupiter:5.9.3)*

------
https://chatgpt.com/codex/tasks/task_e_689aa1f6d8348322a329b6aeeb5ae90a