### PR TITLE
Support Chinese negative prefix

### DIFF
--- a/src/main/java/tw/klab/utils/ChineseNumberTool.java
+++ b/src/main/java/tw/klab/utils/ChineseNumberTool.java
@@ -13,8 +13,8 @@ import java.util.regex.Pattern;
  */
 public class ChineseNumberTool {
 
-    // 支援到「億」單位並允許可選的負號
-    private static final String regexStr = "(-?十?(?:[零一二兩三四五六七八九][十百千萬億]?億?萬?)+點?[零一二三四五六七八九]*)";
+    // 支援到「億」單位並允許可選的負號（- 或「負」）
+    private static final String regexStr = "([-負]?十?(?:[零一二兩三四五六七八九][十百千萬億]?億?萬?)+點?[零一二三四五六七八九]*)";
     private static final Pattern pattern = Pattern.compile(regexStr);
     private static final Map<Character, Character> nextUnit = Map.of(
         '萬', '千',
@@ -79,6 +79,10 @@ public class ChineseNumberTool {
     public static String chineseCharToArabic(String str) {
         var sb = new StringBuilder();
         for (var c : str.toCharArray()) {
+            if (c == '負') {
+                sb.append('-');
+                continue;
+            }
             var i = chineseNumerals.indexOf(c);
             if (i >= 0) {
                 sb.append(i);
@@ -98,7 +102,7 @@ public class ChineseNumberTool {
      */
     public static Optional<Integer> chineseNumeralToArabic(String str) {
         boolean negative = false;
-        if (str.startsWith("-")) {
+        if (str.startsWith("-") || str.startsWith("負")) {
             negative = true;
             str = str.substring(1);
         }

--- a/src/test/java/tw/klab/utils/ChineseNumberToolTest.java
+++ b/src/test/java/tw/klab/utils/ChineseNumberToolTest.java
@@ -16,8 +16,22 @@ class ChineseNumberToolTest {
     }
 
     @Test
+    void parseHandlesYiAndChineseNegative() {
+        String input = "身價負一億零五萬";
+        String expected = "身價-100050000";
+        assertEquals(expected, ChineseNumberTool.parse(input));
+    }
+
+    @Test
     void parseHandlesDecimal() {
         String input = "利潤-三點五";
+        String expected = "利潤-3.5";
+        assertEquals(expected, ChineseNumberTool.parse(input));
+    }
+
+    @Test
+    void parseHandlesChineseNegativeDecimal() {
+        String input = "利潤負三點五";
         String expected = "利潤-3.5";
         assertEquals(expected, ChineseNumberTool.parse(input));
     }
@@ -27,5 +41,17 @@ class ChineseNumberToolTest {
         Optional<Integer> value = ChineseNumberTool.chineseNumeralToArabic("-一億零三萬");
         assertTrue(value.isPresent());
         assertEquals(-100030000, value.get().intValue());
+    }
+
+    @Test
+    void chineseNumeralToArabicReturnsChineseNegative() {
+        Optional<Integer> value = ChineseNumberTool.chineseNumeralToArabic("負一億零三萬");
+        assertTrue(value.isPresent());
+        assertEquals(-100030000, value.get().intValue());
+    }
+
+    @Test
+    void chineseCharToArabicHandlesChineseNegative() {
+        assertEquals("-5", ChineseNumberTool.chineseCharToArabic("負五"));
     }
 }


### PR DESCRIPTION
## Summary
- allow "負" prefix to denote negative numbers
- convert Chinese negative sign to '-' when converting digits
- add unit tests covering "負" prefixed numbers

## Testing
- `gradle test` *(fails: Could not resolve org.junit:junit-bom:5.10.2. Could not GET https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.10.2/junit-bom-5.10.2.pom. Received status code 403 from server: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689aaff51a2c83229bf7cf2630fa5e0c